### PR TITLE
140 bytes file size with short syntax for arrays

### DIFF
--- a/twittee.php
+++ b/twittee.php
@@ -1,7 +1,7 @@
 <?php
 
 class Container {
- private $s=array();
+ private $s=[];
  function __set($k, $c) { $this->s[$k]=$c; }
  function __get($k) { return $this->s[$k]($this); }
 }


### PR DESCRIPTION
Reduce the total file size to 140 bytes by using short syntax for arrays (available from php 5.4) for array initialization.